### PR TITLE
refactor: modifiy Billingegroup/release-scripts to scikit-package-scripts in URLs as the repository has been migrated.

### DIFF
--- a/.github/workflows/_build-wheel-release-upload.yml
+++ b/.github/workflows/_build-wheel-release-upload.yml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Update CHANGELOG.rst with the latest news
         run: |
-          wget https://raw.githubusercontent.com/Billingegroup/release-scripts/v0/.github/workflows/update-changelog.py
+          wget https://raw.githubusercontent.com/scikit-package/release-scripts/v0/.github/workflows/update-changelog.py
           python update-changelog.py "${{ github.ref_name }}"
           rm update-changelog.py
 
@@ -79,7 +79,7 @@ jobs:
     # For a full release, we delete and create a new tag to reflect the latest changes in the CHANGELOG.rst.
     # Recall that during the full release, the `main` branch's CHANGELOG.rst has been updated, and we want the
     # tag to reflect the latest changes in the CHANGELOG.rst done by the update-changelog above.
-    # For more discussions, please read https://github.com/Billingegroup/release-scripts/pull/120
+    # For more discussions, please read https://github.com/scikit-package/release-scripts/pull/120
     needs: [update-changelog]
     # Always run this job for a full release but fail if the update-changelog job previously failed.
     if: "always() && !contains(github.ref, 'rc')"
@@ -147,7 +147,7 @@ jobs:
           ref: main
       - name: Generate GH release notes for release
         run: |
-          wget https://raw.githubusercontent.com/Billingegroup/release-scripts/v0/.github/workflows/get-latest-changelog.py
+          wget https://raw.githubusercontent.com/scikit-package/release-scripts/v0/.github/workflows/get-latest-changelog.py
           python get-latest-changelog.py "${{ github.ref_name }}"
       - name: Release
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/_check-news-item.yml
+++ b/.github/workflows/_check-news-item.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Check News Item
         run: |
           pip install PyGithub
-          wget https://raw.githubusercontent.com/Billingegroup/release-scripts/main/.github/workflows/check-news.py
+          wget https://raw.githubusercontent.com/scikit-package/release-scripts/main/.github/workflows/check-news.py
           python check-news.py
         env:
           PR_NUMBER: "${{ github.event.number }}"

--- a/.github/workflows/check-news-item.yml
+++ b/.github/workflows/check-news-item.yml
@@ -7,6 +7,6 @@ on:
 
 jobs:
   check-news-item:
-    uses: Billingegroup/release-scripts/.github/workflows/_check-news-item.yml@v0
+    uses: scikit-package/release-scripts/.github/workflows/_check-news-item.yml@v0
     with:
       project: scikit-package

--- a/.github/workflows/check-news.py
+++ b/.github/workflows/check-news.py
@@ -60,7 +60,7 @@ def main():
 **Warning!** No news item is found for this PR. If this is a user-facing change/feature/fix,
 please add a news item by copying the format from `news/TEMPLATE.rst`.
 For best practices, please visit
-https://billingegroup.github.io/scikit-package/frequently-asked-questions.html#billinge-group-standards.
+https://scikit-package.github.io/scikit-package/frequently-asked-questions.html#billinge-group-standards.
 """
             )
         assert False

--- a/.github/workflows/templates/build-wheel-release-upload.yml
+++ b/.github/workflows/templates/build-wheel-release-upload.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   release:
-    uses: Billingegroup/release-scripts/.github/workflows/_build-wheel-release-upload.yml@{{ VERSION/v0 }}
+    uses: scikit-package/release-scripts/.github/workflows/_build-wheel-release-upload.yml@{{ VERSION/v0 }}
     with:
       project: {{ PROJECT/PROJECT_NAME }}
       c_extension: {{ C_EXTENSION/false }}

--- a/.github/workflows/templates/check-news-item.yml
+++ b/.github/workflows/templates/check-news-item.yml
@@ -7,6 +7,6 @@ on:
 
 jobs:
   check-news-item:
-    uses: Billingegroup/release-scripts/.github/workflows/_check-news-item.yml@{{ VERSION/v0 }}
+    uses: scikit-package/release-scripts/.github/workflows/_check-news-item.yml@{{ VERSION/v0 }}
     with:
       project: {{ PROJECT/PROJECT_NAME }}

--- a/.github/workflows/templates/matrix-and-codecov-on-merge-to-main.yml
+++ b/.github/workflows/templates/matrix-and-codecov-on-merge-to-main.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   matrix-coverage:
-    uses: Billingegroup/release-scripts/.github/workflows/_matrix-and-codecov-on-merge-to-main.yml@{{ VERSION/v0 }}
+    uses: scikit-package/release-scripts/.github/workflows/_matrix-and-codecov-on-merge-to-main.yml@{{ VERSION/v0 }}
     with:
       project: {{ PROJECT/PROJECT_NAME }}
       c_extension: {{ C_EXTENSION/false }}

--- a/.github/workflows/templates/publish-docs-on-release.yml
+++ b/.github/workflows/templates/publish-docs-on-release.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   docs:
-    uses: Billingegroup/release-scripts/.github/workflows/_publish-docs-on-release.yml@{{ VERSION/v0 }}
+    uses: scikit-package/release-scripts/.github/workflows/_publish-docs-on-release.yml@{{ VERSION/v0 }}
     with:
       project: {{ PROJECT/PROJECT_NAME }}
       c_extension: {{ C_EXTENSION/false }}

--- a/.github/workflows/templates/tests-on-pr.yml
+++ b/.github/workflows/templates/tests-on-pr.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   tests-on-pr:
-    uses: Billingegroup/release-scripts/.github/workflows/_tests-on-pr.yml@{{ VERSION/v0 }}
+    uses: scikit-package/release-scripts/.github/workflows/_tests-on-pr.yml@{{ VERSION/v0 }}
     with:
       project: {{ PROJECT/PROJECT_NAME }}
       c_extension: {{ C_EXTENSION/false }}

--- a/news/update-url.rst
+++ b/news/update-url.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* Modifiy Billingegroup/release-scripts to scikit-package-scripts in URLs as the repository has been migrated.
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/update_workflow.py
+++ b/update_workflow.py
@@ -27,7 +27,7 @@ proj = (
 
 pwd = os.path.dirname(__file__)
 
-CENTRAL_REPO_ORG = "Billingegroup"
+CENTRAL_REPO_ORG = "scikit-package"
 CENTRAL_REPO_NAME = "release-scripts"
 CENTRAL_WORKFLOW_DIR = ".github/workflows/templates"
 LOCAL_WORKFLOW_DIR = Path(pwd + "/../" + proj + "/.github/workflows")


### PR DESCRIPTION
### What problem does this PR address?

Addresses https://github.com/scikit-package/scikit-package/issues/433

We recently transfer repos from `Billingegroup` to `scikit-package`. So this PR updates URLs in the doc and variables.

(test) global search result:

<img width="351" alt="Screenshot 2025-05-13 at 2 39 20 PM" src="https://github.com/user-attachments/assets/f9467f43-ef00-4e83-b48d-3e85db69eec1" />

### What should the reviewer(s) do?

Please review the new URLs and merge the code. 

- [x] This PR introduces a public-facing change (e.g., figures, CLI input/output, API).
    - [x] Documentation (e.g., tutorials, examples, README) has been updated.
    - [x] A tracking issue or plan to update documentation exists.

