### PR TITLE
Add `run:` option under `test-on-pr.yml `to allow running custom CLI commands like extra pip install.

### DIFF
--- a/.github/workflows/_tests-on-pr.yml
+++ b/.github/workflows/_tests-on-pr.yml
@@ -67,7 +67,7 @@ jobs:
           fi
           python -m pip install . --no-deps
 
-      - name: Run extra user CLI commands
+      - name: Run extra user-defined CLI commands
         run: |
           echo "${{ inputs.run }}" > user-commands.sh
           bash user-commands.sh

--- a/.github/workflows/_tests-on-pr.yml
+++ b/.github/workflows/_tests-on-pr.yml
@@ -23,6 +23,11 @@ on:
         default: false
         required: false
         type: boolean
+      run:
+        description: 'Extra CLI commands to run after installing the project'
+        default: 'echo "No extra commands"'
+        required: false
+        type: string
     secrets:
       CODECOV_TOKEN:
         description: 'Codecov token'
@@ -61,6 +66,11 @@ jobs:
             conda install --file requirements/build.txt
           fi
           python -m pip install . --no-deps
+
+      - name: Run extra user CLI commands
+        run: |
+          echo "${{ inputs.run }}" > user-commands.sh
+          bash user-commands.sh
 
       - name: Start Xvfb
         if: ${{ inputs.headless }}

--- a/news/run-command.rst
+++ b/news/run-command.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Add run: option under test-on-pr.yml to allow running custom CLI commands like extra pip install.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
### What problem does this PR address?

Closes #164

`run:` commands works:

```
jobs:
  tests-on-pr:
    uses: bobleesj/release-scripts/.github/workflows/_tests-on-pr.yml@run-command
    with:
      project: bobleesj.release
      c_extension: false
      headless: false
      run: |
        pip install gooey
        echo "Done"
```

<img width="611" alt="Screenshot 2025-06-26 at 4 39 47 PM" src="https://github.com/user-attachments/assets/54e6a501-ed57-46f5-a835-2fef9d7cdd37" />

Ref CI: https://github.com/bobleesj-test-org/bobleesj.release/actions/runs/15895768623/job/44826878474?pr=31

### What should the reviewer(s) do?

Please review and merge. 

- [x] This PR introduces a public-facing change (e.g., figures, CLI input/output, API).
    - [ ] Documentation (e.g., tutorials, examples, README) has been updated.
    - [x] A tracking issue or plan to update documentation exists.
- [ ] This PR affects internal functionality only (no user-facing change).
