### PR TITLE
Install tests.txt instead of test.txt for tests-on-PR and matrix CI.

### DIFF
--- a/.github/workflows/_matrix-and-codecov-on-merge-to-main.yml
+++ b/.github/workflows/_matrix-and-codecov-on-merge-to-main.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Install ${{ inputs.project }} and requirements
         run: |
           conda install --file requirements/conda.txt
-          conda install --file requirements/test.txt
+          conda install --file requirements/tests.txt
           if ${{ inputs.c_extension }}; then
             conda install --file requirements/build.txt
           fi

--- a/.github/workflows/_tests-on-pr-no-codecov-no-headless.yml
+++ b/.github/workflows/_tests-on-pr-no-codecov-no-headless.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Install package and requirements
         run: |
           conda install --file requirements/conda.txt
-          conda install --file requirements/test.txt
+          conda install --file requirements/tests.txt
           python -m pip install . --no-deps
 
       - name: Run extra user-defined CLI commands

--- a/.github/workflows/_tests-on-pr.yml
+++ b/.github/workflows/_tests-on-pr.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Install ${{ inputs.project }} and requirements
         run: |
           conda install --file requirements/conda.txt
-          conda install --file requirements/test.txt
+          conda install --file requirements/tests.txt
           if ${{ inputs.c_extension }}; then
             conda install --file requirements/build.txt
           fi

--- a/news/test-to-tests.rst
+++ b/news/test-to-tests.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Install tests.txt instead of test.txt for tests-on-PR and matrix CI.
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
### What problem does this PR address?

Addresses https://github.com/scikit-package/scikit-package/pull/562#issuecomment-3026574360

Using `tests.txt` instead of `test.txt` - fixed globally. 

Once this is merged, could you please merge from `main` to `v0`?

