### PR TITLE
ci: add new workflow that doesn't upload to codecov

### DIFF
--- a/.github/workflows/_tests-on-pr-no-codecov.yml
+++ b/.github/workflows/_tests-on-pr-no-codecov.yml
@@ -1,0 +1,85 @@
+name: Tests on PR
+
+on:
+  workflow_call:
+    inputs:
+      project:
+        description: 'Name of the project to test'
+        default: 'PROJECT_NAME'
+        required: false
+        type: string
+      python_version:
+        description: 'Python version for Conda environment'
+        default: 3.13
+        required: false
+        type: number
+      c_extension:
+        description: 'Whether the project has a C extension'
+        default: false
+        required: false
+        type: boolean
+      headless:
+        description: 'Whether to run headless tests'
+        default: false
+        required: false
+        type: boolean
+      run:
+        description: 'Extra CLI commands to run after installing the project'
+        default: 'echo "No extra commands"'
+        required: false
+        type: string
+
+jobs:
+  validate:
+    defaults:
+      run:
+        shell: bash -l {0}
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out ${{ inputs.project }}
+        uses: actions/checkout@v4
+
+      - name: Initialize miniconda
+        uses: conda-incubator/setup-miniconda@v3
+        with:
+          activate-environment: test
+          channels: conda-forge
+          auto-update-conda: true
+          auto-activate-base: false
+          python-version: ${{ inputs.python_version }}
+
+      - name: Conda config
+        run: >-
+          conda config --set always_yes yes
+          --set changeps1 no
+
+      - name: Install ${{ inputs.project }} and requirements
+        run: |
+          conda install --file requirements/conda.txt
+          conda install --file requirements/tests.txt
+          if ${{ inputs.c_extension }}; then
+            conda install --file requirements/build.txt
+          fi
+          python -m pip install . --no-deps
+
+      - name: Run extra user-defined CLI commands
+        run: |
+          echo "${{ inputs.run }}" > user-commands.sh
+          bash user-commands.sh
+
+      - name: Start Xvfb
+        if: ${{ inputs.headless }}
+        run: |
+          sudo apt-get install -y xvfb
+          export DISPLAY=:99
+          Xvfb :99 -screen 0 1024x768x16 &
+
+      - name: Validate ${{ inputs.project }}
+        run: |
+          if ${{ inputs.headless }}; then
+            export DISPLAY=:99
+          fi
+          pytest --cov
+          coverage report -m
+          codecov

--- a/news/add-no-codecov-workflow.rst
+++ b/news/add-no-codecov-workflow.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Add tests-on-pr workflow file that doesn't upload to codecov for private repos
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
### What problem does this PR address?
In private repositories, the GitHub CI cannot be run properly. For example, there is an issue with uploading coverage to Codecov, which would result in the CI failing. Thus, a new workflow file that follows the centralized workflow in `_tests-on-pr.yml` but doesn't upload to Codecov is necessary.
Reference: https://github.com/diffpy/diffpy.pdfgetx/pull/134#issuecomment-3066331386
 
### What should the reviewer(s) do?
Please review and merge if this looks okay. After this is merged, could you also merge from `main` into `v0`?